### PR TITLE
Forward args to deps-deploy

### DIFF
--- a/src/build_edn/core.clj
+++ b/src/build_edn/core.clj
@@ -124,16 +124,14 @@
 
 (defn deploy
   [arg]
-  (assert (and (getenv "CLOJARS_USERNAME")
-               (getenv "CLOJARS_PASSWORD"))
-          "CLOJARS_USERNAME and CLOJARS_PASSWORD are required")
   (let [{:as config :keys [lib version class-dir]} (gen-config arg)
         _ (validate-config! config)
         arg (assoc arg :config config)
         jar-file (jar arg)]
-    (deploy/deploy {:artifact jar-file
-                    :installer :remote
-                    :pom-file (b/pom-path {:lib lib :class-dir class-dir})})
+    (deploy/deploy (merge arg
+                          {:artifact jar-file
+                           :installer :remote
+                           :pom-file (b/pom-path {:lib lib :class-dir class-dir})}))
     (set-gha-output config "version" version)
     version))
 


### PR DESCRIPTION
Fixes #3 

I just realized deps-deploy already has some credential management support with maven's settings.xml config file (https://github.com/slipset/deps-deploy/issues/2). This patch forward `exec-args` of `build.edn` into `deps-deploy` so that we can configure repository information with `build.edn`.

Typical usage for clojars. 

1. Add clojars credential to `server` section of `settings.xml`.
2. Add `:repository "clojars"` to `:exec-args` of `build.edn` alias
3. profit.