### PR TITLE
Add support for :match-exactly in :documents

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,6 +1,7 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of http://keepachangelog.com/[keepachangelog.com].
 
 == Unreleased (dev)
+* Added support for `:match-exactly` in `:documents`.
 
 == 0.9.216 (2023-05-03)
 // {{{

--- a/doc/format/documents.adoc
+++ b/doc/format/documents.adoc
@@ -15,7 +15,12 @@
 | `string?`
 | Yes for actions excepting `create`
 | Regexp for matching base line in the `:file`
-
+|
+| match-exactly
+| `string?`
+| Can be used as an alternative to `match`.
+| Plain string for matching base line in the `:file`
+|
 | action
 | `:append-before`, `:replace`, `:append-after` or `:create`
 | Yes

--- a/src/build_edn/core.clj
+++ b/src/build_edn/core.clj
@@ -13,7 +13,8 @@
    [malli.error :as me]
    [malli.util :as mu]
    [pogonos.core :as pg]
-   [rewrite-clj.zip :as z]))
+   [rewrite-clj.zip :as z])
+  (:import (java.util.regex Pattern)))
 
 (def ^:private default-configs
   {:class-dir "target/classes"
@@ -209,8 +210,11 @@
                           be.schema/?documents-build-config)
         _ (validate-config! ?schema config)
         render-data (generate-render-data config)]
-    (doseq [{:keys [file match action text keep-indent?]} documents
-            :let [regexp (when (string? match)
+    (doseq [{:keys [file match match-exactly action text keep-indent?]} documents
+            :let [match (if (string? match-exactly)
+                            (Pattern/quote match-exactly)
+                            match)
+                  regexp (when (string? match)
                            (re-pattern match))
                   text (pg/render-string text render-data)]]
       (if (= :create action)

--- a/src/build_edn/schema.clj
+++ b/src/build_edn/schema.clj
@@ -39,6 +39,12 @@
     [:text string?]]
    [:map {:closed true}
     [:file string?]
+    [:match-exactly string?]
+    [:action [:enum :append-before :replace :append-after]]
+    [:keep-indent? {:optional true} boolean?]
+    [:text string?]]
+   [:map {:closed true}
+    [:file string?]
     [:action [:enum :create]]
     [:text string?]]])
 

--- a/test/build_edn/core_test.clj
+++ b/test/build_edn/core_test.clj
@@ -399,6 +399,20 @@
         (t/is (= {"foo.txt" "foo\nbar\nbaz\n"}
                  @updated)))))
 
+  (t/testing "match-exactly"
+    (let [updated (atom {})]
+      (with-redefs [slurp (constantly "a_b_c\na.b.c\n")
+                    spit (fn [f content]
+                           (swap! updated assoc f content))]
+        (sut/update-documents {:lib 'foo/bar
+                               :version "1.2.{{commit-count}}"
+                               :documents [{:file "foo.txt"
+                                            :match-exactly "a.b.c"
+                                            :action :replace
+                                            :text "baz"}]})
+        (t/is (= {"foo.txt" "a_b_c\nbaz\n"}
+                 @updated)))))
+
   (t/testing "keep-indent?"
     (let [updated (atom {})]
       (with-redefs [slurp (constantly "foo\n  bar")


### PR DESCRIPTION
Hi @liquidz 

and thanks for many great open source projects!

I've added support for `:match-verbatim` in `:documents`.
Is that of interested for the project? I think it's good not to have to escape e.g. the dot (`.`) when doing replace.

I don't know malli and I guess that the new `?document` schema could be improved. Feel free to tweak it as you like.

Appreciate your feedback.
Kind regards