### PR TITLE
Don't force a build.edn file

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
         io.github.clojure/tools.build {:mvn/version "0.9.6"}
         rewrite-clj/rewrite-clj {:mvn/version "1.1.47"}
         metosin/malli {:mvn/version "0.13.0"}
-        slipset/deps-deploy {:mvn/version "0.2.1"}
+        slipset/deps-deploy {:mvn/version "0.2.2"}
         pogonos/pogonos {:mvn/version "0.2.1"}
         aero/aero {:mvn/version "1.1.6"}}
 

--- a/src/build_edn/main.clj
+++ b/src/build_edn/main.clj
@@ -2,7 +2,7 @@
   (:require
    [aero.core :as aero]
    [build-edn.core :as core]
-   [clojure.java.io :as jio]))
+   [clojure.java.io :as io]))
 
 (defn- load-config
   ([]

--- a/src/build_edn/main.clj
+++ b/src/build_edn/main.clj
@@ -8,7 +8,7 @@
   ([]
    (load-config "build.edn"))
   ([path]
-   (if (.exists (jio/file path))
+   (if (.exists (io/file path))
      (-> path
          (aero/read-config)
          (assoc :config-file path))

--- a/src/build_edn/main.clj
+++ b/src/build_edn/main.clj
@@ -1,15 +1,18 @@
 (ns build-edn.main
   (:require
    [aero.core :as aero]
-   [build-edn.core :as core]))
+   [build-edn.core :as core]
+   [clojure.java.io :as jio]))
 
 (defn- load-config
   ([]
    (load-config "build.edn"))
   ([path]
-   (-> path
-       (aero/read-config)
-       (assoc :config-file path))))
+   (if (.exists (jio/file path))
+     (-> path
+         (aero/read-config)
+         (assoc :config-file path))
+     {})))
 
 (defn pom
   "Generate pom.xml"

--- a/src/build_edn/repository.clj
+++ b/src/build_edn/repository.clj
@@ -1,8 +1,8 @@
 (ns build-edn.repository
   (:require
    [clojure.java.io :as io]
-   [clojure.tools.deps.alpha :as deps]
-   [clojure.tools.deps.alpha.util.maven :as deps.u.maven]
+   [clojure.tools.deps :as deps]
+   [clojure.tools.deps.util.maven :as deps.u.maven]
    [deps-deploy.maven-settings :as dd.maven-settings])
   (:import
    org.apache.maven.settings.Server))

--- a/test/build_edn/repository_test.clj
+++ b/test/build_edn/repository_test.clj
@@ -2,7 +2,7 @@
   (:require
    [build-edn.repository :as sut]
    [clojure.test :as t]
-   [clojure.tools.deps.alpha.util.maven :as deps.u.maven]
+   [clojure.tools.deps.util.maven :as deps.u.maven]
    [deps-deploy.maven-settings :as dd.maven-settings])
   (:import
    (org.apache.maven.settings


### PR DESCRIPTION
Don't force a build.edn file.

The user can store all the config needed in deps.edn if she/he likes.

I also bumped deps-deploy. That also required removing the .alpha for tools.deps usage.

What do you think?

Thanks for a great and user friendly project.

Best regards