### PR TITLE
Fixed https://github.com/liquidz/build.edn/issues/38

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,6 +1,10 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of http://keepachangelog.com/[keepachangelog.com].
 
 == Unreleased (dev)
+// {{{
+=== Fixed
+* https://github.com/liquidz/build.edn/issues/38[#38]: Fixed bumping of version so it resets minor or patch to 0 when bumping major or minor, as per semver.
+// }}}
 
 == 0.11.257 (2024-04-12)
 // {{{

--- a/src/build_edn/version.clj
+++ b/src/build_edn/version.clj
@@ -44,10 +44,17 @@
    (bump-version parsed-version :patch))
   ([parsed-version :- ?parsed-version
     version-type :- ?version-type]
-   (let [target-key (keyword "version" (name version-type))]
+   (let [target-key (keyword "version" (name version-type))
+         order [:version/major :version/minor :version/patch]
+         reset-keys (->> order (drop-while #(not= target-key %)) rest)]
      (when-let [new-version (some-> (get parsed-version target-key)
                                     parse-long inc str)]
-       (assoc parsed-version target-key new-version)))))
+       (reduce (fn [acc key]
+                 (if (= "{{git/commit-count}}" (get acc key))
+                   acc
+                   (assoc acc key "0")))
+               (assoc parsed-version target-key new-version)
+               reset-keys)))))
 
 (mx/defn add-snapshot
   :- ?parsed-version

--- a/test/build_edn/version_test.clj
+++ b/test/build_edn/version_test.clj
@@ -48,11 +48,11 @@
 (t/deftest bump-version-test
   (let [v (sut/parse-semantic-version "1.2.3")]
     (t/testing "major"
-      (t/is (= "2.2.3"
+      (t/is (= "2.0.0"
                (-> (sut/bump-version v :major)
                    (sut/to-semantic-version)))))
     (t/testing "minor"
-      (t/is (= "1.3.3"
+      (t/is (= "1.3.0"
                (-> (sut/bump-version v :minor)
                    (sut/to-semantic-version)))))
     (t/testing "patch"


### PR DESCRIPTION
Fixed bumbing of version so it resets minor or patch to 0 when bumping major or minor, as per semver.

I added a changelog under unreleased, and did not change the versions or anything in order to make a release, I just made the fix.